### PR TITLE
Build the Haxe project just pressing F5 or F6

### DIFF
--- a/icons/haxe.svg.import
+++ b/icons/haxe.svg.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/scenes/building.tscn
+++ b/scenes/building.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://addons/haxe/scripts/building.gd" type="Script" id=1]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0.219608, 0.211765, 0.227451, 1 )
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color( 0.270588, 0.270588, 0.270588, 1 )
+corner_radius_top_left = 4
+
+[node name="Control" type="Control"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -152.0
+margin_top = -38.5
+margin_right = 152.0
+margin_bottom = 38.5
+script = ExtResource( 1 )
+
+[node name="Background" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_styles/panel = SubResource( 1 )
+
+[node name="Label" type="Label" parent="."]
+anchor_right = 1.0
+margin_bottom = 26.0
+text = "Building Haxe project..."
+align = 1
+valign = 1
+autowrap = true
+clip_text = true
+
+[node name="ProgressBar" type="ProgressBar" parent="."]
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+margin_left = 11.0
+margin_top = -6.5
+margin_right = -11.0
+margin_bottom = 7.5
+max_value = 1.0

--- a/scripts/building.gd
+++ b/scripts/building.gd
@@ -9,6 +9,8 @@ func build_haxe_project():
 	var res = OS.execute("haxe", ["build.hxml"], true);
 		
 	$ProgressBar.value = 1
+	yield(VisualServer, 'frame_post_draw')
+	
 	print("Project builded with code: ", res)
 
 	queue_free()

--- a/scripts/building.gd
+++ b/scripts/building.gd
@@ -1,0 +1,14 @@
+tool
+class_name Building
+
+extends Control
+
+func build_haxe_project():
+	print("Building haxe project...");
+
+	var res = OS.execute("haxe", ["build.hxml"], true);
+		
+	$ProgressBar.value = 1
+	print("Project builded with code: ", res)
+
+	queue_free()

--- a/scripts/constants.gd
+++ b/scripts/constants.gd
@@ -3,3 +3,4 @@ class_name HaxePluginConstants
 
 const SETTING_HIDE_NATIVE_SCRIPT_FIELD := "haxe/hide_native_script_field"
 const SETTING_EXTERNAL_EDITOR := "haxe/external_editor"
+const BUILD_ON_PLAY := "haxe/build_on_play"

--- a/scripts/haxe.gd
+++ b/scripts/haxe.gd
@@ -4,6 +4,7 @@ extends EditorPlugin
 
 var about_dialog := preload("res://addons/haxe/scenes/about.tscn")
 var tab := preload("res://addons/haxe/scenes/tab.tscn").instance()
+var build_dialog := preload("res://addons/haxe/scenes/building.tscn")
 
 var inspector_plugin:HaxePluginInspectorPlugin
 
@@ -50,7 +51,7 @@ func setup_settings() -> void:
 		});
 
 	if not ProjectSettings.has_setting(HaxePluginConstants.BUILD_ON_PLAY):
-		ProjectSettings.set_setting(HaxePluginConstants.BUILD_ON_PLAY, true)
+		ProjectSettings.set_setting(HaxePluginConstants.BUILD_ON_PLAY, false)
 
 func on_menu(id:int) -> void:
 	var theme := get_editor_interface().get_base_control().theme
@@ -93,4 +94,10 @@ func on_menu(id:int) -> void:
 func _input(event):
 	if event is InputEventKey and ProjectSettings.get_setting(HaxePluginConstants.BUILD_ON_PLAY):
 		if event.scancode == KEY_F5 or event.scancode == KEY_F6 and event.echo:
-			OS.execute("haxe", ["build.hxml"], true);
+			var dialog = build_dialog.instance()
+
+			add_child(dialog)
+
+			yield(VisualServer, 'frame_post_draw')
+
+			dialog.call("build_haxe_project")

--- a/scripts/haxe.gd
+++ b/scripts/haxe.gd
@@ -49,6 +49,9 @@ func setup_settings() -> void:
 			"hint_string": "None,VSCode"
 		});
 
+	if not ProjectSettings.has_setting(HaxePluginConstants.BUILD_ON_PLAY):
+		ProjectSettings.set_setting(HaxePluginConstants.BUILD_ON_PLAY, true)
+
 func on_menu(id:int) -> void:
 	var theme := get_editor_interface().get_base_control().theme
 	
@@ -88,6 +91,6 @@ func on_menu(id:int) -> void:
 		print("Unknown menu: ", id)
 
 func _input(event):
-	if event is InputEventKey:
+	if event is InputEventKey and ProjectSettings.get_setting(HaxePluginConstants.BUILD_ON_PLAY):
 		if event.scancode == KEY_F5 or event.scancode == KEY_F6 and event.echo:
-			tab.build_haxe_project()
+			OS.execute("haxe", ["build.hxml"], true);

--- a/scripts/haxe.gd
+++ b/scripts/haxe.gd
@@ -86,3 +86,8 @@ func on_menu(id:int) -> void:
 		dialog.popup_centered()
 	else:
 		print("Unknown menu: ", id)
+
+func _input(event):
+	if event is InputEventKey:
+		if event.scancode == KEY_F5 or event.scancode == KEY_F6 and event.echo:
+			tab.build_haxe_project()


### PR DESCRIPTION
Hello, When I was developing a game using Haxe and Godot I found that building 2 times (The Haxe project and the game) is uncomfortable so I added the support for building just pressing the play buttons.

Also I added an option called "Build On Play" that is enabled by default, If the developer disables it obviously the project will not be built automatically. 

![image](https://user-images.githubusercontent.com/37759352/157127991-9bbbdacd-b452-413b-8d49-8140266130e4.png)

I tested this changes on 2 PCs, One with Windows and the other with Debian and it works.

Note: I don't know if the way that I added this feature is the best so I'm open to suggestions... hehe